### PR TITLE
Respond with 500 in case no object is detected by the sensor.

### DIFF
--- a/settings.toml
+++ b/settings.toml
@@ -3,6 +3,11 @@
 # The base area of the cistern in m²
 base_area = 1.2
 
+[sensor]
+
+# The distance in m returned by the sensor in case no object has been detected
+no_detection_distance = 5.0
+
 [detection]
 
 # The serial port to which the sonar sensor is connected.


### PR DESCRIPTION
Resolves #3. Range reported by sensor in case no object is detected can be specified in `settings.toml`. In that case `GET /cistern/state` returns a `500` status code.